### PR TITLE
Update DockerHub Deployment

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -29,15 +29,13 @@ jobs:
     # Build the Docker image
     - name: Build
       run: |        
-        docker build -t "$DOCKER_ORGANIZATION"/"$IMAGE":$(echo ${GITHUB_SHA} | cut -c1-8)\
-          --build-arg GITHUB_SHA="$GITHUB_SHA" \
-          --build-arg GITHUB_REF="$GITHUB_REF" .
+        docker build -t "$DOCKER_ORGANIZATION"/"$IMAGE":$(echo ${GITHUB_SHA} | cut -c1-8) .
         docker tag "$DOCKER_ORGANIZATION"/"$IMAGE":$(echo ${GITHUB_SHA} | cut -c1-8) "$DOCKER_ORGANIZATION"/"$IMAGE":latest
 
-    # Push the Docker image to Google Container Registry
+    # Push the Docker image to DockerHub
     - name: Publish
       run: |
         docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD 
-        docker push $DOCKER_ORGANIZATION/$IMAGE:$(echo ${GITHUB_SHA} | cut -c1-8)
+        docker push $DOCKER_ORGANIZATION/$IMAGE
       env:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -29,16 +29,15 @@ jobs:
     # Build the Docker image
     - name: Build
       run: |        
-        docker build -t "$DOCKER_ORGANIZATION"/"$IMAGE":"$GITHUB_SHA" \
+        docker build -t "$DOCKER_ORGANIZATION"/"$IMAGE":$(echo ${GITHUB_SHA} | cut -c1-8)\
           --build-arg GITHUB_SHA="$GITHUB_SHA" \
           --build-arg GITHUB_REF="$GITHUB_REF" .
-        docker tag "$DOCKER_ORGANIZATION"/"$IMAGE":"$GITHUB_SHA" "$DOCKER_ORGANIZATION"/"$IMAGE":latest
+        docker tag "$DOCKER_ORGANIZATION"/"$IMAGE":$(echo ${GITHUB_SHA} | cut -c1-8) "$DOCKER_ORGANIZATION"/"$IMAGE":latest
 
     # Push the Docker image to Google Container Registry
     - name: Publish
       run: |
         docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD 
-        docker push $DOCKER_ORGANIZATION/$IMAGE:$GITHUB_SHA
-        docker push $DOCKER_ORGANIZATION/$IMAGE:latest
+        docker push $DOCKER_ORGANIZATION/$IMAGE:$(echo ${GITHUB_SHA} | cut -c1-8)
       env:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Resolves #8 
- Uses short SHA instead of full SHA for image tagging
- Removes redundant DockerHub push.