### PR TITLE
Initialize and Protect Problem Count

### DIFF
--- a/src/controllers/problemSet.ts
+++ b/src/controllers/problemSet.ts
@@ -86,7 +86,8 @@ const problemSetController = {
         } else {
             try {
                 const problemSetData: IProblemSet = {
-                    ...req.body
+                    ...req.body,
+                    problemCount: 0
                 };
 
                 const newProblemSet: IProblemSetModel = await problemSetDBInteractions.create(
@@ -118,7 +119,8 @@ const problemSetController = {
                     });
                 else {
                     const updatedProblemSetBody: IProblemSet = {
-                        ...req.body
+                        ...req.body,
+                        problemCount: problemSet.problemCount
                     };
 
                     const updatedProblemSet: IProblemSetModel = await problemSetDBInteractions.update(

--- a/tests/unit/controllers/problemSet.test.ts
+++ b/tests/unit/controllers/problemSet.test.ts
@@ -232,7 +232,10 @@ describe("Problem sets controller tests", () => {
             );
             await problemSetController.create(req, mockRes);
             sinon.assert.calledOnce(stubs.problemSetDB.create);
-            sinon.assert.calledWith(stubs.problemSetDB.create, req.body);
+            sinon.assert.calledWith(stubs.problemSetDB.create, {
+                ...req.body,
+                problemCount: 0
+            });
             sinon.assert.calledWith(mockRes.status, statusCodes.SUCCESS);
             sinon.assert.calledWith(mockRes.json, testProblemSetModel1);
         });
@@ -259,7 +262,10 @@ describe("Problem sets controller tests", () => {
             );
             await problemSetController.create(req, mockRes);
             sinon.assert.calledOnce(stubs.problemSetDB.create);
-            sinon.assert.calledWith(stubs.problemSetDB.create, req.body);
+            sinon.assert.calledWith(stubs.problemSetDB.create, {
+                ...req.body,
+                problemCount: 0
+            });
             sinon.assert.calledWith(mockRes.status, statusCodes.SERVER_ERROR);
         });
     });
@@ -301,6 +307,36 @@ describe("Problem sets controller tests", () => {
                 stubs.problemSetDB.update,
                 req.params.problemSetId,
                 req.body
+            );
+            sinon.assert.calledWith(mockRes.status, statusCodes.SUCCESS);
+            sinon.assert.calledWith(mockRes.json, updatedUser);
+        });
+
+        it("status 200: returns successfully unchanged problemCount", async () => {
+            stubs.validators.validationResult.returns(
+                <any>emptyValidationError()
+            );
+            stubs.problemSetDB.find.resolves(testProblemSetModel1);
+
+            const updatedUser = JSON.parse(JSON.stringify(testProblemSet1));
+            updatedUser._id = req.params.problemSetId;
+            updatedUser.title = "Test Problem Set Title 1 Updated";
+            updatedUser.problemCount = 9;
+            stubs.problemSetDB.update.resolves(updatedUser);
+
+            req.body.title = "Test Problem Set Title 1 Updated";
+            await problemSetController.update(req, mockRes);
+
+            sinon.assert.calledOnce(stubs.problemSetDB.find);
+            sinon.assert.calledOnce(stubs.problemSetDB.update);
+            sinon.assert.calledWith(
+                stubs.problemSetDB.find,
+                req.params.problemSetId
+            );
+            sinon.assert.calledWith(
+                stubs.problemSetDB.update,
+                req.params.problemSetId,
+                { ...req.body, problemCount: testProblemSet1.problemCount }
             );
             sinon.assert.calledWith(mockRes.status, statusCodes.SUCCESS);
             sinon.assert.calledWith(mockRes.json, updatedUser);


### PR DESCRIPTION
Initializes Problem Count field upon creation.
Protects Problem Count from modification on update endpoint.
resolve #33
resolve #15